### PR TITLE
Add method to calculate total element count and update version to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.twme</groupId>
     <artifactId>BDEngineParser</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <name>BDEngine Parser Library</name>
     <description>A library for parsing BDEngine project structures.</description>

--- a/src/main/java/dev/twme/bdengineparser/BDEngineParser.java
+++ b/src/main/java/dev/twme/bdengineparser/BDEngineParser.java
@@ -219,4 +219,40 @@ public class BDEngineParser {
         // We call the static method from our internal TransformUtils
         return TransformUtils.createRotationAroundAxisMatrix(axis, angleRad);
     }
+
+    /**
+     * Calculates the total number of elements (including all children recursively)
+     * in a given list of root {@link ProjectElement}s.
+     *
+     * @param rootElements The list of root ProjectElement objects.
+     * @return The total count of all elements. Returns 0 if the list is null or empty.
+     */
+    public int getTotalElementCount(List<ProjectElement> rootElements) {
+        if (rootElements == null || rootElements.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        for (ProjectElement element : rootElements) {
+            count += countElementsRecursive(element);
+        }
+        return count;
+    }
+
+    /**
+     * Helper method to recursively count an element and its children.
+     * @param element The current ProjectElement.
+     * @return The count of this element plus all its descendants.
+     */
+    private int countElementsRecursive(ProjectElement element) {
+        if (element == null) {
+            return 0;
+        }
+        int count = 1; // Count the current element
+        if (element.getChildren() != null) {
+            for (ProjectElement child : element.getChildren()) {
+                count += countElementsRecursive(child); // Add count of children
+            }
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
Introduce a new method to calculate the total number of elements in a list of `ProjectElement` objects, including their children. Update the project version to 2.2 in the `pom.xml` file.